### PR TITLE
Set default testing env id to empty str

### DIFF
--- a/tools/get_testing_env_id.py
+++ b/tools/get_testing_env_id.py
@@ -1,13 +1,20 @@
 import sys
 import json
+import logging
 
 
 def get_testing_env_id():
-    with open("build/deploy_testing_context.json", "r") as f:
-        context = json.load(f)
-        env_id = context["EnvironmentId"]
-    if not env_id or type(env_id) != str:
-        raise ValueError
+    fp = "build/deploy_testing_context.json"
+    try:
+        with open(fp, "r") as f:
+            context = json.load(f)
+            env_id = context["EnvironmentId"]
+        if not env_id or type(env_id) != str:
+            raise ValueError(f"Testing environment id set in file: '{fp}' is invalid.")
+    except FileNotFoundError:
+        logging.warning(f"Testing environment id is now set to an empty string, "
+                        f"because file: '{fp}' wasn't found.")
+        env_id = ""
     return env_id
 
 


### PR DESCRIPTION
Testing stack is synthed too on deploy and needs the id.