### PR TITLE
Fix getting the admin key

### DIFF
--- a/backend/middleware/utils.py
+++ b/backend/middleware/utils.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 import boto3
 import os
 import logging
+import json
 
 
 class Authenticator:
@@ -23,8 +24,8 @@ class Authenticator:
             service_name='secretsmanager',
             region_name="us-east-1"
         )
-        resp = client.get_secret_value(SecretId="blog-backend-admin-key")
-        return resp['SecretString']
+        string = client.get_secret_value(SecretId="blog-backend-admin-key")['SecretString']
+        return json.loads(string)["blog-backend-admin-key"]
 
     def register(self, key):
         """Sets the admin status (bool) of the current user by comparing the user's key"""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,6 @@
 import boto3
 import functools
+import json
 
 
 @functools.cache
@@ -9,4 +10,5 @@ def get_admin_key():
         service_name='secretsmanager',
         region_name="us-east-1"
     )
-    return client.get_secret_value(SecretId="blog-backend-admin-key")['SecretString']
+    string = client.get_secret_value(SecretId="blog-backend-admin-key")['SecretString']
+    return json.loads(string)["blog-backend-admin-key"]


### PR DESCRIPTION
The boto3 secretsmanager api wasn't used propely. Backend and backend tests used the same code to get the admin key, so the mistake wasn't detected.